### PR TITLE
73_eufySecurity.pm

### DIFF
--- a/opt/fhem/FHEM/73_eufyCamera.pm
+++ b/opt/fhem/FHEM/73_eufyCamera.pm
@@ -5,9 +5,10 @@
 package main;
 
 # Laden evtl. abhängiger Perl- bzw. FHEM-Hilfsmodule
+use Data::Dumper qw(Dumper);
 
 # Wenn 1 werden alle Attribute und Parameter als Readings im Device dargestellt
-my $DEBUG_READINGS = 1;
+my $DEBUG_READINGS = 0;
 
 # eufy Security Device Typen
 my %DeviceType = (
@@ -22,7 +23,7 @@ my %DeviceType = (
     9  => [ 'CAMERA2',          'eufyCam 2' ],
     10 => [ 'MOTION_SENSOR',    'Motion Sesor' ],
     11 => [ 'KEYPAD',           'Keypad' ],
-    30 => [ 'INDOOR_CAMERA',    'Indoor Camera 2k' ],
+    30 => [ 'INDOOR_CAMERA',    'Indoor Camera 2k' ],    # Cam & Station in one device
     31 => [ 'INDOOR_PT_CAMERA', 'Indoor PR Camera' ],
     50 => [ 'LOCK_BASIC',       'Lock Basic' ],
     51 => [ 'LOCK_ADVANCED',    'Lock Advanced' ],
@@ -85,6 +86,8 @@ sub eufyCamera_Define($$) {
     # Device ggf. den Raum eufySecurity zuweisen
     CommandAttr( undef, $name . ' room eufySecurity' ) if ( AttrVal( $name, 'room', 'none' ) eq 'none' );
     CommandAttr( undef, $name . ' icon it_camera' )    if ( AttrVal( $name, 'icon', 'none' ) eq 'none' );
+    CommandAttr( undef, $name . ' userReadings battery { ReadingsVal($NAME,"battery_level",0) > 10 ? "ok" : "low"}' )
+      if ( AttrVal( $name, 'userReadings', 'none' ) eq 'none' );
 
     # Default-Werte für schnellen API-Zugriff im $hash ablegen
 
@@ -95,14 +98,15 @@ sub eufyCamera_Define($$) {
 }
 
 sub eufyCamera_Undef($$) {
-    my ( $hash, $name ) = @_;
+    my ( $hash,        $name )      = @_;
+    my ( $device_type, $device_sn ) = $hash->{DEF};
 
     # TBD: Hier noch offene Verbindungne schliessen
 
     # Readings auf Default-Werte setzen
 
     Log3 $name, 3, "eufyCamera (Undef) - undefined $name";
-
+    delete $modules{eufyCamera}{defptr}{$device_sn};
     return undef;
 }
 
@@ -141,7 +145,7 @@ sub eufyCamera_Get($$@) {
         Log3 $name, 3, "eufyCamera $name (get) - IOWrite return: $ret";
     }
     else {
-        return "Unknown argument $opt, choose one of update";
+        return "Unknown argument $opt, choose one of update:noArg";
     }
 
     return undef;
@@ -163,80 +167,101 @@ sub eufyCamera_Parse ($$) {
     if ( my $hash = $modules{eufyCamera}{defptr}{$device_sn} ) {
 
         # Nachricht für $hash verarbeiten
-        Log3 $name, 3, "eufyCamera (Parse) - device_sn" . $device_sn . " im Hash gefunden, starte UPDATE";
+        Log3 $name, 3, "eufyCamera (Parse) - device_sn" . $device_sn . " found in the hash";
 
-        # Set alias ti device_name
-        CommandAttr( undef, $name . ' alias ' . $io_hash->{helper}{UPDATE}{device_name} );
+        if ( $cmd eq 'UPDATE' ) {
+            Log3 $name, 3, "eufyCamera (Parse) - device_sn" . $device_sn . " start UPDATE";
 
-        if ($DEBUG_READINGS) {
-            readingsBeginUpdate($hash);
-            while ( ( $key, $val ) = each %{ $io_hash->{helper}{UPDATE} } ) {
-                if ( $key ne 'params' ) {
-                    if ( substr( $key, -5 ) eq '_time' ) {
-                        readingsBulkUpdateIfChanged( $hash, $key, FmtDateTime($val), 1 );
+            # copy data of io_hash to device hash
+            $hash->{data} = $io_hash->{helper}{UPDATE};
+
+            # rename key params tp params_old and convert array to hash
+            $hash->{data}{params_old} = delete $hash->{data}{params};
+            for ( $i = 0 ; $i < @{ $hash->{data}{params_old} } ; $i++ ) {
+                my $param_type = $hash->{data}{params_old}[$i]{param_type};
+                delete $hash->{data}{params_old}[$i]{param_type};
+                delete $hash->{data}{params_old}[$i]{device_sn};
+                $hash->{data}{params}{$param_type} = $hash->{data}{params_old}[$i];
+            }
+            delete $hash->{data}{params_old};
+
+            #Log3 $name, 3, "eufyStation $name (Parse) - Dumper " . Dumper( $hash->{data} );
+
+            # Set alias to device_name
+            CommandAttr( undef, $name . ' alias ' . $hash->{data}{device_name} );
+
+            if ($DEBUG_READINGS) {
+                Log3 $name, 3, "eufyCamera $name (Parse) - Generate all attributes as Reading";
+                readingsBeginUpdate($hash);
+                while ( ( $key, $val ) = each %{ $io_hash->{data} } ) {
+                    if ( $key eq 'params' ) {
+
+                        # set reading for params
+                        while ( ( $p, $h ) = each %{ $hash->{data}{params} } ) {
+                            my $param_type = $p;
+                            while ( ( $k, $v ) = each %{$h} ) {
+                                readingsBulkUpdateIfChanged( $hash, "params/$param_type/$k", $hash->{data}{params}{$k}{param_value}, 1 );
+                            }
+                        }
+                    }
+                    elsif ( $key eq 'station_conn' or $key eq 'member' ) {
+                        while ( ( $k, $v ) = each %{ $io_hash->{data}{$key} } ) {
+                            if ( substr( $k, -5 ) eq '_time' ) {
+                                readingsBulkUpdateIfChanged( $hash, $key . "/" . $k, FmtDateTime($v), 1 );
+                            }
+                            else {
+                                readingsBulkUpdateIfChanged( $hash, $key . "/" . $k, $v, 1 );
+                            }
+                        }
                     }
                     else {
-                        if ( $key eq 'station_conn' or $key eq 'member' ) {
-                            while ( ( $k, $v ) = each %{ $io_hash->{helper}{UPDATE}{$key} } ) {
-                                if ( substr( $k, -5 ) eq '_time' ) {
-                                    readingsBulkUpdateIfChanged( $hash, $key . "/" . $k, FmtDateTime($v), 1 );
-                                }
-                                else {
-                                    readingsBulkUpdateIfChanged( $hash, $key . "/" . $k, $v, 1 );
-                                }
-                            }
+                        if ( substr( $key, -5 ) eq '_time' ) {
+                            readingsBulkUpdateIfChanged( $hash, $key, FmtDateTime($val), 1 );
                         }
                         else {
                             readingsBulkUpdateIfChanged( $hash, $key, $val, 1 );
                         }
                     }
-
                 }
-                else {
-                    # set reading for param array
-                    for ( $param = 0 ; $param < @{ $io_hash->{helper}{UPDATE}{params} } ; $param++ ) {
-                        readingsBulkUpdateIfChanged(
-                            $hash,
-                            $io_hash->{helper}{UPDATE}{params}[$param]{param_type},
-                            $io_hash->{helper}{UPDATE}{params}[$param]{param_value}, 1
-                        );
-                    }
-                }
-
+                readingsEndUpdate( $hash, 1 );
             }
-            readingsEndUpdate( $hash, 1 );
+            else {
+                # Log3 $name, 3, "eufyCamera (Parse) - Dumper UPDATE-Hash\n".Dumper($io_hash->{helper}{UPDATE})."\n";
+
+                # Update der relevanten Readings
+                readingsBeginUpdate($hash);
+
+                #readingsBulkUpdateIfChanged( $hash, 'bind_time',        FmtDateTime( $hash->{data}{bind_time} ),1 );
+                #readingsBulkUpdateIfChanged( $hash, 'charging_days',    $hash->{data}{charging_days},1 );
+                #readingsBulkUpdateIfChanged( $hash, 'charging_missing', $hash->{data}{charging_missing},1 );
+                #readingsBulkUpdateIfChanged( $hash, 'charging_reserve', $hash->{data}{charging_reserve},1 );
+                #readingsBulkUpdateIfChanged( $hash, 'charing_total',    $hash->{data}{charing_total},1 );
+                #readingsBulkUpdateIfChanged( $hash, 'cover_path',       $hash->{data}{cover_path} );
+                #readingsBulkUpdateIfChanged( $hash, 'cover_time',       FmtDateTime( $hash->{data}{cover_time} ),1 );
+                #readingsBulkUpdateIfChanged( $hash, 'device_id',        $hash->{data}{device_id},1 );
+                readingsBulkUpdateIfChanged( $hash, 'create_time',     FmtDateTime( $hash->{data}{create_time} ),          1 );
+                readingsBulkUpdateIfChanged( $hash, 'device_channel',  $hash->{data}{device_channel},                      1 );
+                readingsBulkUpdateIfChanged( $hash, 'device_model',    $hash->{data}{device_model},                        1 );
+                readingsBulkUpdateIfChanged( $hash, 'device_type',     $DeviceType{ $hash->{data}{device_type} }[1],       1 );
+                readingsBulkUpdateIfChanged( $hash, 'event_num',       $hash->{data}{event_num},                           1 );
+                readingsBulkUpdateIfChanged( $hash, 'main_hw_version', $hash->{data}{main_hw_version},                     1 );
+                readingsBulkUpdateIfChanged( $hash, 'main_sw_version', $hash->{data}{UPDATE}{main_sw_version},             1 );
+                readingsBulkUpdateIfChanged( $hash, 'main_sw_time',    FmtDateTime( $hash->{data}{UPDATE}{main_sw_time} ), 1 );
+                readingsBulkUpdateIfChanged( $hash, 'sec_sw_version',  $hash->{data}{sec_sw_version},                      1 );
+                readingsBulkUpdateIfChanged( $hash, 'sec_sw_time',     FmtDateTime( $hash->{data}{sec_sw_time} ),          1 );
+                readingsBulkUpdateIfChanged( $hash, 'update_time',     FmtDateTime( $hash->{data}{update_time} ),          1 );
+                readingsBulkUpdateIfChanged( $hash, 'state',           $hash->{data}{status},                              1 );
+                readingsBulkUpdateIfChanged( $hash, 'battery_level',   $hash->{data}{params}{1101}{param_value},           1 );
+                readingsBulkUpdateIfChanged( $hash, 'wifiRSSI',        $hash->{data}{params}{1142}{param_value},           1 );
+                readingsEndUpdate( $hash, 1 );
+            }
+
+            # Rückgabe des Gerätenamens, für welches die Nachricht bestimmt ist.
+            return $hash->{NAME};
         }
         else {
-
-            # Update der relevanten Readings
-            readingsBeginUpdate($hash);
-            readingsBulkUpdate( $hash, 'bind_time',        FmtDateTime( $io_hash->{helper}{UPDATE}{bind_time} ) );
-            readingsBulkUpdate( $hash, 'charging_days',    $io_hash->{helper}{UPDATE}{charging_days} );
-            readingsBulkUpdate( $hash, 'charging_missing', $io_hash->{helper}{UPDATE}{charging_missing} );
-            readingsBulkUpdate( $hash, 'charging_reserve', $io_hash->{helper}{UPDATE}{charging_reserve} );
-            readingsBulkUpdate( $hash, 'charing_total',    $io_hash->{helper}{UPDATE}{charing_total} );
-            readingsBulkUpdate( $hash, 'cover_path',       $io_hash->{helper}{UPDATE}{cover_path} );
-            readingsBulkUpdate( $hash, 'cover_time',       FmtDateTime( $io_hash->{helper}{UPDATE}{cover_time} ) );
-            readingsBulkUpdate( $hash, 'create_time',      FmtDateTime( $io_hash->{helper}{UPDATE}{create_time} ) );
-            readingsBulkUpdate( $hash, 'device_channel',   $io_hash->{helper}{UPDATE}{device_channel} );
-            readingsBulkUpdate( $hash, 'device_id',        $io_hash->{helper}{UPDATE}{device_id} );
-            readingsBulkUpdate( $hash, 'device_model',     $io_hash->{helper}{UPDATE}{device_model} );
-            readingsBulkUpdate( $hash, 'device_sn',        $io_hash->{helper}{UPDATE}{device_sn} );
-            readingsBulkUpdate( $hash, 'device_type',      $DeviceType{ $io_hash->{helper}{UPDATE}{device_type} }[1] );
-            readingsBulkUpdate( $hash, 'event_num',        $io_hash->{helper}{UPDATE}{event_num} );
-            readingsBulkUpdate( $hash, 'main_hw_version',  $io_hash->{helper}{UPDATE}{main_hw_version} );
-            readingsBulkUpdate( $hash, 'main_sw_version',  $io_hash->{helper}{UPDATE}{main_sw_version} );
-            readingsBulkUpdate( $hash, 'main_sw_time',     FmtDateTime( $io_hash->{helper}{UPDATE}{main_sw_time} ) );
-            readingsBulkUpdate( $hash, 'sec_sw_version',   $io_hash->{helper}{UPDATE}{sec_sw_version} );
-            readingsBulkUpdate( $hash, 'sec_sw_time',      FmtDateTime( $io_hash->{helper}{UPDATE}{sec_sw_time} ) );
-            readingsBulkUpdate( $hash, 'station_sn',       $io_hash->{helper}{UPDATE}{station_sn} );
-            readingsBulkUpdate( $hash, 'update_time',      FmtDateTime( $io_hash->{helper}{UPDATE}{update_time} ) );
-            readingsBulkUpdate( $hash, 'state',            $io_hash->{helper}{UPDATE}{status} );
-            readingsEndUpdate( $hash, 1 );
+            Log3 $name, 3, "eufyCamera $name (Parse) - Unknown cmd $cmd";
         }
-
-        # Rückgabe des Gerätenamens, für welches die Nachricht bestimmt ist.
-        return $hash->{NAME};
     }
     else {
         # Keine Gerätedefinition verfügbar

--- a/opt/fhem/FHEM/73_eufySecurity.pm
+++ b/opt/fhem/FHEM/73_eufySecurity.pm
@@ -9,6 +9,8 @@ use HttpUtils;
 use JSON;
 use Encode;
 use utf8;
+use IO::Socket;
+use Data::Dumper qw(Dumper);
 
 # eufy Security Device Typen
 my %DeviceType = (
@@ -32,11 +34,37 @@ my %DeviceType = (
 
 # eufy Security Guard Mode
 my %GuardMode = (
-    0  => [ 'AWAY',     'Abwesend' ],
-    1  => [ 'HOME',     'Zuhause' ],
-    2  => [ 'SCHEDULE', 'Zeitplan' ],
-    63 => [ 'DISARMED', 'Deaktiviert' ]
+    0  => [ 'AWAY',       'Abwesend' ],
+    1  => [ 'HOME',       'Zuhause' ],
+    2  => [ 'SCHEDULE',   'Zeitplan' ],
+    47 => [ 'GEOFENCING', 'Geofencing' ],
+    63 => [ 'DISARMED',   'Deaktiviert' ]
 );
+
+use constant RequestMessageType => {
+    LOOKUP_WITH_DSK => "\xf1\x26",
+    LOCAL_LOOKUP    => "\xf1\x30",
+    CHECK_CAM       => "\xf1\x41",
+    PING            => "\xf1\xe0",
+    PONG            => "\xf1\xe1",
+    DATA            => "\xf1\xd0",
+    ACK             => "\xf1\xd1"
+};
+
+use constant ResponseMessageType => {
+    STUN              => "\xf1\x01",
+    LOOKUP_RESP       => "\xf1\x21",
+    LOOKUP_ADDR       => "\xf1\x40",
+    LOCAL_LOOKUP_RESP => "\xf1\x41",
+    END               => "\xf1\xf0",
+    PONG              => "\xf1\xe1",
+    PING              => "\xf1\xe0",
+    CAM_ID            => "\xf1\x42",
+    ACK               => "\xf1\xd1",
+    DATA              => "\xf1\xd0"
+};
+
+use constant MAGIC_WORD => 'XZYH';
 
 # eufy Securiyt Parameter Keys
 my %ParamKey = (
@@ -97,35 +125,35 @@ my $BaseURL = 'https://security-app-eu.eufylife.com/v1/';
 sub eufySecurity_Initialize($) {
     my ($hash) = @_;
 
-    $hash->{DefFn}    = "eufySecurity_Define";
-    $hash->{UndefFn}  = "eufySecurity_Undef";
-    $hash->{DeleteFn} = "eufySecurity_Delete";
-    $hash->{RenameFn} = "eufySecurity_Rename";
-    $hash->{SetFn}    = "eufySecurity_Set";
-    $hash->{GetFn}    = "eufySecurity_Get";
-
-    #$hash->{AttrFn}   = "eufySecurity_Attr";
+    $hash->{DefFn}      = "eufySecurity_Define";
+    $hash->{UndefFn}    = "eufySecurity_Undef";
+    $hash->{DeleteFn}   = "eufySecurity_Delete";
+    $hash->{ShutdownFn} = "eufySecurity_Shutdown";
+    $hash->{RenameFn}   = "eufySecurity_Rename";
+    $hash->{SetFn}      = "eufySecurity_Set";
+    $hash->{GetFn}      = "eufySecurity_Get";
+    $hash->{ReadFn}     = "eufySecurity_Read";
 
     # Noch nicht implementierte Funktionen auskommentiert
-    #$hash->{ReadFn}               = "eufySecurity_Read";
+    #$hash->{AttrFn}   = "eufySecurity_Attr";
     #$hash->{ReadyFn}              = "eufySecurity_Ready";
     #$hash->{NotifyFn}             = "eufySecurity_Notify";
-    #$hash->{ShutdownFn}           = "eufySecurity_Shutdown";
-    #$hash->{DelayedShutdownFn}    = "eufySecurity_ DelayedShutdown";rmat
+    #$hash->{DelayedShutdownFn}    = "eufySecurity_ DelayedShutdown";
 
     # Funktionen für zweistufiges Modulkonzept
     $hash->{WriteFn}       = "eufySecurity_Write";
     $hash->{FingerprintFn} = "eufySecurity_Fingerprint";
     $hash->{Clients}       = "eufyStation:eufyCamera";
 
-    # Aufbau der Nachrich an die logischen Module
-    # <device_type>:<device_name>:<cmd>
+    # Aufbau der Nachricht an die logischen Module
+    # <device_type>:<device_name>:<cmd>[:<args>]
     #
     # <device_type> => numerisch (z.B. 9 für eufyCam 2)
     # <device_name> => Name des Device in FHEM. Format
     #                  Format: <moduld_name>_<device_sn>
     #                  z.B. eufyCamera_T8114P0220272D96
     # <cmd>.        => Kommando an logisches Modul z.B. UPDATE
+	# <args>.       => optional weitere Argumente duch einen Doppelpunkt getrennt (abhängig von <cmd>)
     $hash->{MatchList} = {
         "1:eufyCamera"  => "^(1|7|8|9|30):.*",
         "2:eufyStation" => "^0:.*"
@@ -134,6 +162,7 @@ sub eufySecurity_Initialize($) {
     $hash->{AttrList} = 'mail ' . 'timeout ' . 'eufySecurity-API-URL' . $readingFnAttributes;
 }
 
+# define eufySecurity_<device_sn> eufySecurity <device_type> <device_sn>
 sub eufySecurity_Define($$) {
     my ( $hash, $def ) = @_;
     my @param = split( '[ \t]+', $def );
@@ -196,10 +225,16 @@ sub eufySecurity_Delete ($$) {
     return undef;
 }
 
+sub eufySecurity_Shutdown($) {
+    my ($hash) = @_;
+
+    #Todo Verbindung für alle offenen Sockets schliessen
+}
+
 sub eufySecurity_Rename($$) {
     my ( $new, $old ) = @_;
 
-    Log 3, "eufySecurity $name (Rename) - old name:$old  new name:$new";
+    Log3 $old, 3, "eufySecurity $old (Rename) - old name:$old  new name:$new";
 
     my $old_key     = "eufySecurity_" . $old . "_password";
     my $new_key     = "eufySecurity_" . $new . "_password";
@@ -208,7 +243,7 @@ sub eufySecurity_Rename($$) {
 
     my ( $err, $enc_pwd ) = getKeyValue($old_key);
 
-    return undef unless(defined($enc_pwd));
+    return undef unless ( defined($enc_pwd) );
 
     my $pwd = decrypt_Password( $enc_pwd, $old_pwd_key );
 
@@ -236,7 +271,7 @@ sub eufySecurity_Set($@) {
         else {
             $pwd = decrypt_Password( $enc_pwd, $pwd_key );
             Log3 $name, 3, "eufySecurity $name (Set) - connect to eufySecurity";
-            connect2eufySecurity( $hash, $name, $mail, $pwd );
+            login2eufySecurity($hash);
 
         }
     }
@@ -257,8 +292,11 @@ sub eufySecurity_Set($@) {
         setKeyValue( $hash->{NAME} . "_password",                       undef );
         setKeyValue( $hash->{TYPE} . "_" . $hash->{NAME} . "_password", undef );
     }
+    elsif ( $cmd eq "GuardMode" ) {
+        #
+    }
     else {
-        return "Unknown argument $cmd, choose one of connect password del_password";
+        return "Unknown argument $cmd, choose one of connect:noArg password GuardMode:Away,Home,Schedule,Geofencing,Disarmed del_password:noArg";
     }
 }
 
@@ -270,58 +308,124 @@ sub eufySecurity_Get($$@) {
     Log3 $name, 3, "eufySecurity $name (Get) - cmd: $opt";
 
     if ( $opt eq "Hubs" ) {
-        getHubs( $hash, '{"device_sn": "", "num": 100, "page": 0, "type": 0, "station_sn": ""}' );
+        if ( isConnected($hash) ) {
+            getHubs( $hash, '{"device_sn": "", "num": 100, "page": 0, "type": 0, "station_sn": ""}' );
+        }
     }
     elsif ( $opt eq "Devices" ) {
-        getDevices( $hash, '{"device_sn": "", "num": 100, "orderby": "", "page": 0, "station_sn": ""}' );
+        if ( isConnected($hash) ) {
+            getDevices( $hash, '{"device_sn": "", "num": 100, "orderby": "", "page": 0, "station_sn": ""}' );
+        }
     }
     elsif ( $opt eq "History" ) {
-        my $param = {
-            url      => $BaseURL . 'event/app/get_all_history_record',
-            header   => "Content-Type: application/json\r\n" . "x-auth-token: " . $hash->{connection}{auth_token},
-            data     => '{"device_sn": "","end_time": 0,"id": 0,"num": 100,"offset": -14400,"pullup": true,"shared": true,"start_time": 0,"storage": 0}',
-            method   => "POST",
-            hash     => $hash,
-            loglevel => 5,
-            timeout  => 10,
-            callback => \&getHistoryCB
-        };
-        HttpUtils_NonblockingGet($param);
+        if ( isConnected($hash) ) {
+            my $param = {
+                url      => $BaseURL . 'event/app/get_all_history_record',
+                header   => "Content-Type: application/json\r\n" . "x-auth-token: " . $hash->{connection}{auth_token},
+                data     => '{"device_sn": "","end_time": 0,"id": 0,"num": 100,"offset": -14400,"pullup": true,"shared": true,"start_time": 0,"storage": 0}',
+                method   => "POST",
+                hash     => $hash,
+                loglevel => 5,
+                timeout  => 10,
+                callback => \&getHistoryCB
+            };
+            HttpUtils_NonblockingGet($param);
+        }
     }
     elsif ( $opt eq "DEBUG_DskKey" ) {
-
-        getDskKey( $hash, '{"device_sn": "", "num": 100, "orderby": "", "page": 0, "station_sn": "T8010P2320270E8D"}' );
-        getDskKey( $hash, '{"station_sns": "T8010P2320270E8D"}' );
-    }
-    elsif ( $opt eq "DEBUG_RenameFn" ) {
-        return $hash->{RenameFn};
-        1;
+        getDskKey( $hash, '{"station_sns": ["T8010P2320270E8D"]}' );
     }
     else {
-        return "Unknown argument $opt, choose one of Hubs Devices History DEBUG_DskKey DEBUG_RenameFn";
+        return "Unknown argument $opt, choose one of Hubs:noArg Devices:noArg History:noArg DEBUG_DskKey:noArg";
     }
+}
+
+sub eufySecurity_Read($) {
+    my ($shash) = @_;    # ACHTUNG: Hier wird der Hash des Sockets übergeben und NICHT der Hash des Moduls!
+
+    my $sock = $shash->{FH};
+
+    # Hash des Moduls
+    my $parent = $shash->{PARENT};
+    my $hash   = $defs{$parent};
+    my $name   = $hash->{NAME};
+
+    my $buffer;
+    $sock->recv( $buffer, 1024 );
+
+    # if ( hasHeader( $buffer, ResponseMessageType->{PONG} ) ) {
+    #
+    #     # nothing todo
+    #     # responing to a PING from our side
+    #
+    #     return;
+    # }
+    # elsif ( hasHeader( $buffer, ResponseMessageType->{PING} ) ) {
+    #
+    #     #Todo, we have to answer with a PONG
+    #     Log3 $name, 3, "eufySecurity (Read) - receiver END-Message, close connection\n";
+    #
+    #     return;
+    # }
+    # elsif ( hasHeader( $buffer, ResponseMessageType->{END} ) ) {
+    #
+    #     #Todo
+    #     #  - den Socket schliessen
+    #     #  - Status Verbindung auf disconnect setzen
+    #     #  - $shahs aus selectlist löschen
+    # }
+    # elsif ( hasHeader( $buffer, ResponseMessageType->{CAM_ID} ) ) {
+    #
+    #     # Answer from the device to a CAM_CHECK message
+    #
+    #     return;
+    # }
+    # elsif ( hasHeader( $buffer, ResponseMessageType->{ACK} ) ) {
+    #
+    #     #Todo noch weiter in device-client-service.ts analysieren und implementieren
+    #     return;
+    # }
+    # elsif ( hasHeader( $buffer, ResponseMessageType->{DATA} ) )
+    #
+    #   #Todo noch weiter in device-client-service.ts analysieren und implementieren
+    #   return;
+    # else {
+    #     #Todo Hier noch die Station ausgeben, von der das Telegram kommt
+    #     Log3 $name, 3, "eufySecurity (Read) - unknown message type:" . unpack( 'H*', $buffer ) . "\n";
+    # }
 }
 
 sub eufySecurity_Write ($$) {
     my ( $hash, $message, $address ) = @_;
     my $name = $hash->{NAME};
-    my ( $device_type, $sn, $cmd ) = split( /:/, $message );
+    my ( $device_type, $sn, $cmd, @args ) = split( /:/, $message );
 
     Log3 $name, 3, "eufySecurity $name (Write) - device_type:$device_type sn:$sn cmd:$cmd";
 
     if ( $cmd eq "UPDATE_DEVICE" ) {
-        getDevices( $hash, '{"device_sn": "' . $sn . '", "num": 100, "orderby": "", "page": 0, "station_sn": ""}' );
+        if ( isConnected($hash) ) {
+            getDevices( $hash, '{"device_sn": "' . $sn . '", "num": 100, "orderby": "", "page": 0, "station_sn": ""}' );
+        }
         return undef;
     }
     elsif ( $cmd eq "UPDATE_HUB" ) {
-        getHubs( $hash, '{"device_sn": "", "num": 100, "page": 0, "type": 0, "station_sn": "' . $sn . '"}' );
+        if ( isConnected($hash) ) {
+            getHubs( $hash, '{"device_sn": "", "num": 100, "page": 0, "type": 0, "station_sn": "' . $sn . '"}' );
+        }
     }
     elsif ( $cmd eq "GET_DSK_KEY" ) {
-        getDskKey( $hash, '{"station_sns": ["' . $sn . '"]}' );
+        if ( isConnected($hash) ) {
+            getDskKey( $hash, '{"station_sns": ["' . $sn . '"]}' );
+        }
+    }
+    elsif ( $cmd eq "CONNECT_STATION" ) {
+        Log3 $name, 3, "eufySecurity $name (Write) - connect to " . $args[0] . " p2p_did:" . $args[1] . " user_id:" . $args[2];
+    }
+    elsif ( $cmd eq "GUARD_MODE" ) {
+        Log3 $name, 3, "eufySecurity $name (Write) - set Guard Mode to " . $args[0];
     }
     else {
         return "Unknown cmd $cmd";
-
     }
 }
 
@@ -336,85 +440,102 @@ sub eufySecurity_Fingerprint($$) {
     return ( $io_name, $msg );
 }
 
-##############################################################################
-##############################################################################
+# ============================================================================
 # Interne Hilfs-Funktionen
-##############################################################################
-##############################################################################
+# ============================================================================
 
-##############################################################################
+# ----------------------------------------------------------------------------
 # Login to eufySecurity over Web-API
-##############################################################################
-sub connect2eufySecurity ($$@) {
-    my ( $hash, $name, $mail, $pw ) = @_;
-    my $param = {
-
-        url      => $BaseURL . 'passport/login',
-        header   => "Content-Type: application/json",
-        data     => '{"email": "' . $mail . '", "password": "' . $pw . '"}',
-        method   => "POST",
-        hash     => $hash,
-        loglevel => 5,
-        callback => \&connect2eufySecurityCB
-    };
-    Log3 $name, 3, "eufySecurity $name (Login) - url: " . $param->{url};
-
-    HttpUtils_NonblockingGet($param);
-}
-
-##############################################################################
-# Callback Function Login
-##############################################################################
-sub connect2eufySecurityCB($$$) {
-    my ( $param, $err, $data ) = @_;
-    my $json;
-    my $hash = $param->{hash};
+# ----------------------------------------------------------------------------
+sub login2eufySecurity($) {
+    my $hash = shift;
     my $name = $hash->{NAME};
 
-    if ( $err eq "" ) {    # kein Fehler aufgetreten
-        Log3 $name, 3, "eufySecurity (Callback Login) - data: $data";
+    my $mail = AttrVal( $name, 'mail', '' );
 
-        ### Check if json can be parsed into hash
-        eval {
-            $json = decode_json(encode_utf8($data));
-            1;
-        } or do {
-            ### Log Entry for debugging purposes
-            Log3 $name, 3, "eufySecurity (Callback Login) - Error decode json $json";
-            return "eufySecurity (Callback Login) - Error decode json";
-        };
+    my $key     = $hash->{TYPE} . "_" . $name . '_password';
+    my $pwd_key = getUniqueId() . $key;
+    my ( $err, $enc_pwd ) = getKeyValue($key);
 
-        if ( $json->{code} == 0 ) {
-            $hash->{connection}{auth_token}       = $json->{data}{auth_token};
-            $hash->{connection}{token_expires_at} = $json->{data}{token_expires_at};
-            $hash->{connection}{user_id}          = $json->{data}{user_id};
-            $hash->{connection}{state}            = "connect";
-
-            readingsBeginUpdate($hash);
-            if ( $json->{data}{domain} ne "" ) {
-
-                # change domain of BaseURL to given domain
-                #			$BaseURL = 'https://'.$json->{data}{domain}.'/apieu/v1/';
-            }
-
-            readingsBulkUpdateIfChanged( $hash, 'eufySecurity-API-URL', $BaseURL, 1 );
-
-            readingsBulkUpdate( $hash, 'token',         $hash->{connection}{auth_token} );
-            readingsBulkUpdate( $hash, 'token_expires', FmtDateTime( $hash->{connection}{token_expires_at} ) );
-            readingsBulkUpdate( $hash, 'state',         $hash->{connection}{state} );
-            readingsBulkUpdate( $hash, 'user_id',       $hash->{connection}{user_id} );
-            readingsEndUpdate( $hash, 1 );
-        }
-        else {
-            Log3 $name, 3, "eufySecurity (Callback Login) - eufy Security Fehler bei connect code: " . $json->{code} . " msg: " . $json->{msg};
-        }
-
+    if ( defined $err ) {
+        Log3 $name, 3, "eufySecurity $name (login2eufySecurity) no password set or reading error";
+        return 0;
     }
     else {
-        Log3 $name, 3, "eufySecurity (Callback Login) - HttpUtils Fehler bei connect $err";
+        $pwd = decrypt_Password( $enc_pwd, $pwd_key );
+        Log3 $name, 3, "eufySecurity $name (login2eufySecurity) - Login to eufySecurity";
+
+        my $param = {
+            url    => $BaseURL . 'passport/login',
+            header => "Content-Type: application/json",
+            data   => '{"email": "' . $mail . '", "password": "' . $pwd . '"}',
+            method => "POST"
+        };
+
+        Log3 $name, 3, "eufySecurity $name (login2eufySecurity) - url: " . $param->{url};
+
+        my ( $err, $data ) = HttpUtils_BlockingGet($param);
+
+        if ( $err eq "" ) {    # kein Fehler aufgetreten
+            Log3 $name, 3, "eufySecurity (login2eufySecurity) - receive data: $data";
+
+            ### Check if json can be parsed into hash
+            eval {
+                $json = decode_json( encode_utf8($data) );
+                1;
+            } or do {
+                ### Log Entry for debugging purposes
+                Log3 $name, 3, "eufySecurity (login2eufySecurity) - Error decode json $json";
+                return 0;
+            };
+
+            if ( $json->{code} == 0 ) {
+                $hash->{connection}{auth_token}       = $json->{data}{auth_token};
+                $hash->{connection}{token_expires_at} = $json->{data}{token_expires_at};
+                $hash->{connection}{user_id}          = $json->{data}{user_id};
+                $hash->{connection}{state}            = "connect";
+
+                readingsBeginUpdate($hash);
+                readingsBulkUpdateIfChanged( $hash, 'eufySecurity-API-URL', $BaseURL,                                             1 );
+                readingsBulkUpdateIfChanged( $hash, 'token',                $hash->{connection}{auth_token},                      1 );
+                readingsBulkUpdateIfChanged( $hash, 'token_expires',        FmtDateTime( $hash->{connection}{token_expires_at} ), 1 );
+                readingsBulkUpdateIfChanged( $hash, 'state',                $hash->{connection}{state},                           1 );
+                readingsBulkUpdateIfChanged( $hash, 'user_id',              $hash->{connection}{user_id},                         1 );
+                readingsEndUpdate( $hash, 1 );
+            }
+            else {
+                Log3 $name, 3, "eufySecurity (login2eufySecurity) - eufySecurity error code: " . $json->{code} . " msg: " . $json->{msg};
+                return 0;
+            }
+        }
+        else {
+            Log3 $name, 3, "eufySecurity (login2eufySecurity) - HttpUtils error $err";
+            return 0;
+        }
+    }
+    return 1;
+}
+
+# ----------------------------------------------------------------------------
+# cchecking the connection and reconnect if nessesary
+# ----------------------------------------------------------------------------
+sub isConnected($) {
+    my $hash = shift;
+    my $name = $hash->{NAME};
+
+    if ( ( $hash->{connection}{state} ne "connect" ) or ( $hash->{connection}{token_expires_at} < localtime() ) ) {
+        Log3 $name, 3, "eufySecurity $name (isConnected) - reconnect to eufySecurity";
+        return login2eufySecurity($hash);
+    }
+    else {
+        Log3 $name, 3, "eufySecurity $name (isConnected) - allready connect to eufySecurity";
+        return 1;
     }
 }
 
+# ----------------------------------------------------------------------------
+# request list of stations
+# ----------------------------------------------------------------------------
 sub getHubs($$) {
     my ( $hash, $data ) = @_;
     my $name = $hash->{NAME};
@@ -435,6 +556,9 @@ sub getHubs($$) {
     HttpUtils_NonblockingGet($param);
 }
 
+# ----------------------------------------------------------------------------
+# Callback for function getHubs
+# ----------------------------------------------------------------------------
 sub getHubsCB($$$) {
     my ( $param, $err, $data ) = @_;
     my $json;
@@ -446,7 +570,7 @@ sub getHubsCB($$$) {
 
         ### Check if json can be parsed into hash
         eval {
-            $json = decode_json(encode_utf8($data));
+            $json = decode_json( encode_utf8($data) );
             1;
         } or do {
             ### Log Entry for debugging purposes
@@ -456,7 +580,7 @@ sub getHubsCB($$$) {
 
         if ( $json->{code} == 0 ) {
             for ( $i = 0 ; $i < @{ $json->{data} } ; $i++ ) {
-                Log3 $name, 3, "eufySecurity $name (Callback getHubs) - json: " . $json->{data};
+                Log3 $name, 3, "eufySecurity $name (Callback getHubs) - [$i] json: " . $json->{data}[$i];
 
                 # Update Daten über (io_)hash an Station übergeben
                 $hash->{helper}{UPDATE} = $json->{data}[$i];
@@ -475,6 +599,9 @@ sub getHubsCB($$$) {
     }
 }
 
+# ----------------------------------------------------------------------------
+# Callback für getHistory
+# ----------------------------------------------------------------------------
 sub getHistoryCB($$$) {
     my ( $param, $err, $data ) = @_;
     my $json;
@@ -486,7 +613,7 @@ sub getHistoryCB($$$) {
 
         ### Check if json can be parsed into hash
         eval {
-            $json = decode_json(encode_utf8($data));
+            $json = decode_json( encode_utf8($data) );
             1;
         } or do {
             ### Log Entry for debugging purposes
@@ -511,29 +638,51 @@ sub getHistoryCB($$$) {
 sub getDskKey($$) {
     my ( $hash, $data ) = @_;
     my $name = $hash->{NAME};
+    my $json;
 
     Log3 $name, 3, "eufySecurity $name (getDskKey) - data: " . $data;
 
     my $param = {
-
-        #url      => $BaseURL . "app/equipment/get_dsk_keys",
-        url      => "https://security-app-eu.eufylife.com/v1/app/equipment/get_dsk_keys",
+        url      => $BaseURL . "app/equipment/get_dsk_keys",
         header   => "Content-Type: application/json\r\n" . "x-auth-token: " . $hash->{connection}{auth_token},
         data     => $data,
         method   => "POST",
         hash     => $hash,
         loglevel => 5,
-        timeout  => 10,
-        callback => \&getHubsCB
+        timeout  => 10
     };
     Log3 $name, 3, "eufySecurity $name (GetDskKey) - url: " . $param->{url};
-    my ( $err, $http_data ) = HttpUtils_BlockingGet($param);
-    Log3 $name, 3, "eufySecurity $name (GetDskKey) - err:$err  http_data: $http_data";
+
+    my ( $err, $data ) = HttpUtils_BlockingGet($param);
+
+    if ( $err eq "" ) {    # kein Fehler aufgetreten
+        Log3 $name, 3, "eufySecurity (getDskKey) - data: $data";
+
+        ### Check if json can be parsed into hash
+        eval {
+            $json = decode_json( encode_utf8($data) );
+            1;
+        } or do {
+            ### Log Entry for debugging purposes
+            Log3 $name, 3, "eufySecurity (getDskKey) - Error decode json";
+            return "eufySecurity (getDskKey) - Error decode json";
+        };
+
+        if ( $json->{code} == 0 ) {
+
+            #$debug = Dumper($json);
+            #Log3 $name, 3, "eufySecurity $name (getDskKey) - debug: $debug";
+            readingsBeginUpdate($hash);
+            readingsBulkUpdateIfChanged( $hash, 'dsk_key',            $json->{data}{dsk_keys}[0]{dsk_key},                   1 );
+            readingsBulkUpdateIfChanged( $hash, 'dsk_key_expiration', FmtDateTime( $json->{data}{dsk_keys}[0]{expiration} ), 1 );
+            readingsEndUpdate( $hash, 1 );
+        }
+    }
 }
 
-##############################################################################
+# ----------------------------------------------------------------------------
 # request list of devices
-##############################################################################
+# ----------------------------------------------------------------------------
 sub getDevices($$) {
     my ( $hash, $data ) = @_;
     my $name = $hash->{NAME};
@@ -554,9 +703,9 @@ sub getDevices($$) {
     HttpUtils_NonblockingGet($param);
 }
 
-##############################################################################
+# ----------------------------------------------------------------------------
 # Callback Fuction for getDevices
-##############################################################################
+# ----------------------------------------------------------------------------
 sub getDevicesCB($$$) {
     my ( $param, $err, $data ) = @_;
     my $json;
@@ -568,7 +717,7 @@ sub getDevicesCB($$$) {
 
         ### Check if json can be parsed into hash
         eval {
-            $json = decode_json(encode_utf8($data));
+            $json = decode_json( encode_utf8($data) );
             1;
         } or do {
             ### Log Entry for debugging purposes
@@ -637,6 +786,14 @@ sub decrypt_Password($$) {
     }
 
     return $dec_pwd;
+}
+
+# ----------------------------------------------------------------------------
+# Return first two bytes of P2P Message
+# ----------------------------------------------------------------------------
+sub hasHeader($$) {
+    my ( $msg, $type ) = @_;
+    return substr( $msg, 0, 2 ) eq $type;
 }
 
 # Eval-Rückgabewert für erfolgreiches

--- a/test/client.pl
+++ b/test/client.pl
@@ -11,35 +11,43 @@ my ( $sock, $server_host, $msg, $port, $ipaddr, $hishost, $MAXLEN, $PORTNO, $TIM
 
 $MAXLEN  = 1024;
 $PORTNO  = 5151;
-$TIMEOUT = 5;
+$TIMEOUT = 1;
 
 $server_host = "localhost";
 $msg         = "Test_";
 my $i = 1;
 
 $sock = IO::Socket::INET->new(
-    Proto    => 'udp',
+    Proto => 'udp',
+
     #Type     => SOCK_DRAM,
     PeerPort => $PORTNO,
     PeerAddr => $server_host
 ) or die "Creating socket: $!\n";
 
-while (1) {
+my $is_connect = 1;
+
+while ($is_connect) {
     my $m = "Test_" . $i++;
 
     $sock->send($m) or die "send: $!";
 
     eval {
-        local $SIG{ALRM} = sub { die "alarm time out" };
+        local $SIG{ALRM} = sub { die "timeout\n" };
         alarm $TIMEOUT;
         $sock->recv( $msg, $MAXLEN ) or die "recv: $!";
         alarm 0;
-        1;    # return value from eval on normalcy
-    } or die "recv from $server_host timed out after $TIMEOUT seconds.\n";
-
-    ( $port, $ipaddr ) = sockaddr_in( $sock->peername );
-    $hishost = gethostbyaddr( $ipaddr, AF_INET );
-    print "Server $hishost responded ``$msg''\n";
-    sleep(10);
+    };
+	print @_."\n";
+    if (@_) {
+        print "Lost connection! Quit client!\n";
+        $is_connect = 0;
+    }
+    else {
+        ( $port, $ipaddr ) = sockaddr_in( $sock->peername );
+        $hishost = gethostbyaddr( $ipaddr, AF_INET );
+        print "Server $hishost responded ``$msg''\n";
+        sleep(3);
+    }
 }
 


### PR DESCRIPTION
- Neue Funktion login2eufySecurity
	- Ersetzt connect2eufySecurity und connect2eufySecurityCB
	- Login ist jetzt ein BockingCall (HttpUtils)
- Neue funktion isConnected
	- Prüft ob eine connect (Web-API) erforderlich ist oder das
	  Token abgelaufen ist. Falls erfoderlich wird die Verbindung
	  wieder aufgebaut (Login)
- Bei Anfragen über die Web-API wird die VErbindung jetzt automatisch
  aufgebaut. D.h. es ist kein expliziter Aufruf von connect erforderlich

Allgemein
- Bei set/get werden jetzt die Optione und z.T. Werte als Listboxen angezeigt.
  Bei Station set GuardMode aber noch ohne Funktion (nur internes Debugging)
- Bei der eufyStation und eufyCamera werden die Update-Information jetzt dauerhaft
  unter $hash->{data} abgelegt.

  Dabei werden die Arrays params und devices (nur Station) in einen Hash konvertiert.
  Bei params ist param_type und bei devices ist device_sn der Key auf die Informationen.